### PR TITLE
Fix: Link to Wiki FAQ page

### DIFF
--- a/react-ui/components/MyApp.js
+++ b/react-ui/components/MyApp.js
@@ -101,7 +101,7 @@ class MyApp extends React.Component {
             <br />
             Please <a href="https://chrome.google.com/webstore/detail/connection-forwarder/ahaijnonphgkgnkbklchdhclailflinn/reviews" target="_blank">leave a review</a> to help others find this software.
             <br />
-            <a href="https://github.com/kzahel/connection-forwarder/wiki/FAQ" target="_blank">FAQ / Help</a>.{' '}
+            <a href="https://github.com/kzahel/connection-forwarder/wiki" target="_blank">FAQ / Help</a>.{' '}
             <a href="https://github.com/kzahel/connection-forwarder/issues" target="_blank">Report an issue</a>
         </div>
 			</div>


### PR DESCRIPTION
This is a quick fix to point the FAQ link on the application to the correct WIKI page. The current setting links through to a blank page. The updated link incorporates the Home page and the FAQ that should be displayed to the user.