### PR TITLE
Fix undefined error

### DIFF
--- a/app/js/background.js
+++ b/app/js/background.js
@@ -11,7 +11,7 @@ chrome.sockets.tcpServer.onAccept.addListener( onAccept )
 function locateForward(id) {
   for (let lsock in Forwards) {
     let lrule = Forwards[lsock].defn
-    if (lrule.id == id) {
+    if (!!lrule && lrule.id == id) {
       return parseInt(lsock)
     }
   }


### PR DESCRIPTION
Connection Forwarder won't start on subsequent uses because this variable is undefined sometimes for some reason. This fixes the issue and permits Connection Forwarder to start again.